### PR TITLE
Client ID field and functionality for Cloud Sites Clients' DNS

### DIFF
--- a/clouddns-gui.py
+++ b/clouddns-gui.py
@@ -320,10 +320,15 @@ def delete_record(domainname=None, recordid=None):
 
     return redirect("/domains/%s" % domainname)
 
-@app.route("/account", methods=['POST'])
+@app.route("/account", methods=['GET','POST'])
 def change_accountId():
     """Handles setting the accountId from the Nav Bar"""
 
+    # Handle a blank GET request to reset the accountId
+    if request.method == 'GET':
+        session.pop('accountId', None) # Remove the accountId from the session
+        return redirect("/domains")
+        
     accountId = request.form['accountId']
 
     ### TODO: VALIDATE!! (numeric, length, etc?)

--- a/clouddns-gui.py
+++ b/clouddns-gui.py
@@ -380,4 +380,4 @@ def setAccount():
 if __name__ == "__main__":
     # Only for running this app via python directly.  This is ignored if you
     # run it through mod_wsgi.
-    app.run(host='0.0.0.0')
+    app.run(host='127.0.0.1')

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -33,6 +33,13 @@
           </a>
           <a class="brand" href="/">Rackspace Cloud DNS GUI</a>
           <div class="nav">
+            <li>
+              <form method="post" action="/account" class="navbar-search">
+                Client ID:
+                <input class="search-query span1" name="accountId" type="text" placeholder="{{g.accountId}}">
+                <button class="btn" type="submit" style="display: none;">Set Account</button>
+              </form>
+            </li>
             <li class="dropdown" id="menu1">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#menu1">
                 Active Domains


### PR DESCRIPTION
I re-factored my previous attempt. This time I decided to use a session variable, and if you looked at the previous one, I am sure you will agree this is a _much_ cleaner option.

This change creates a field in layout (nav header) to specify a clientId (from Cloud Sites client list), in order to edit domains associated with Cloud Sites customers.
